### PR TITLE
Fixing crash in listDatabases

### DIFF
--- a/lib/node-couchdb.js
+++ b/lib/node-couchdb.js
@@ -101,7 +101,7 @@ nodeCouchDB.prototype = {
                 return;
             }
 
-            callback && callback(null, JSON.parse(res));
+            callback && callback(null, JSON.parse(res.data));
         });
     },
 


### PR DESCRIPTION
ListDatabases crashes when parsing the returned data.  It should parse `res.data` not `res`.