### PR TITLE
Special-case handling for 412 and 404 not working

### DIFF
--- a/lib/node-couchdb.js
+++ b/lib/node-couchdb.js
@@ -117,13 +117,18 @@ nodeCouchDB.prototype = {
             method: "PUT",
             timeout: this._defaultTimeout
         }, function (err, res) {
+            var statusCode = err && err.data && err.data.statusCode;
+            if (statusCode == 412) { // database already exists
+                callback && callback(null);
+                return;
+            }
+
             if (err) {
                 callback && callback("Problem with CREATE DATABASE operation: " + err.message);
                 return;
             }
 
             switch (res.statusCode) {
-                case 412 : // database already exists
                 case 201 : // created
                     callback && callback(null);
                     break;
@@ -146,13 +151,18 @@ nodeCouchDB.prototype = {
             method: "DELETE",
             timeout: this._defaultTimeout
         }, function (err, res) {
+            var statusCode = err && err.data && err.data.statusCode;
+            if (statusCode == 404) { // database not found
+                callback && callback(null);
+                return;
+            }
+
             if (err) {
                 callback && callback("Problem with DELETE DATABASE operation: " + err.message);
                 return;
             }
 
             switch (res.statusCode) {
-                case 404 : // database doesn't exist
                 case 200 : // okay
                     callback && callback(null);
                     break;

--- a/tests/test.js
+++ b/tests/test.js
@@ -9,37 +9,43 @@ var commonTest = function (test, cacheAPI) {
 	couch.createDatabase(dbName, function (err) {
 		test.strictEqual(err, null, err);
 
-		couch.insert(dbName, {}, function (err, resData) {
+		// Creating the same database a second time should not cause failure.
+
+		couch.createDatabase(dbName, function (err) {
 			test.strictEqual(err, null, err);
 
-			var docId = resData.data.id;
-
-			couch.get(dbName, docId, function (err, resData) {
+			couch.insert(dbName, {}, function (err, resData) {
 				test.strictEqual(err, null, err);
 
-				test.strictEqual(resData.status, 200, "Result status code is not 200");
-				test.equal(typeof resData, "object", "Result is not an object");
-				test.ok(!!resData.data, "Result data is missing");
-				test.ok(!!resData.status, "Result status is missing");
-				test.ok(!!resData.headers, "Result headers missing");
-				test.equal(Object.keys(resData).length, 3, "Wrong number of resData fields");
+				var docId = resData.data.id;
 
-				// timeout is used because we do not wait for cache.set() callback
-				setTimeout(function () {
-					couch.get(dbName, docId, function (err, resData) {
-						test.strictEqual(err, null, err);
+				couch.get(dbName, docId, function (err, resData) {
+					test.strictEqual(err, null, err);
 
-						test.strictEqual(resData.status, 304, "Result status code is not 304");
-						test.equal(typeof resData, "object", "Result is not an object");
-						test.ok(!!resData.data, "Result data is missing");
-						test.ok(!!resData.status, "Result status is missing");
-						test.ok(!!resData.headers, "Result headers missing");
-						test.equal(Object.keys(resData).length, 3, "Wrong number of resData fields");
+					test.strictEqual(resData.status, 200, "Result status code is not 200");
+					test.equal(typeof resData, "object", "Result is not an object");
+					test.ok(!!resData.data, "Result data is missing");
+					test.ok(!!resData.status, "Result status is missing");
+					test.ok(!!resData.headers, "Result headers missing");
+					test.equal(Object.keys(resData).length, 3, "Wrong number of resData fields");
 
-						couch.dropDatabase("sample");
-						test.done();
-					});
-				}, 1000);
+					// timeout is used because we do not wait for cache.set() callback
+					setTimeout(function () {
+						couch.get(dbName, docId, function (err, resData) {
+							test.strictEqual(err, null, err);
+
+							test.strictEqual(resData.status, 304, "Result status code is not 304");
+							test.equal(typeof resData, "object", "Result is not an object");
+							test.ok(!!resData.data, "Result data is missing");
+							test.ok(!!resData.status, "Result status is missing");
+							test.ok(!!resData.headers, "Result headers missing");
+							test.equal(Object.keys(resData).length, 3, "Wrong number of resData fields");
+
+							couch.dropDatabase("sample");
+							test.done();
+						});
+					}, 1000);
+				});
 			});
 		});
 	});


### PR DESCRIPTION
On the createDatabase call, the special-case handling for 412 (database already exists) was failing (IOW, the error was relayed back to the caller).

Similarly on the dropDatabase call, the special-case handling for 404 (not found) was also failing.