### PR TITLE
Add error checks in INSERT, UPDATE and DELETE of document

### DIFF
--- a/lib/node-couchdb.js
+++ b/lib/node-couchdb.js
@@ -29,7 +29,7 @@ export default class NodeCouchDB {
 
         this._baseUrl = `${instanceOpts.protocol}://${instanceOpts.host}:${instanceOpts.port}`;
         this._cache = instanceOpts.cache;
-        
+
         this._requestWrappedDefaults = request.defaults({
             auth: instanceOpts.auth,
             headers: {
@@ -43,7 +43,7 @@ export default class NodeCouchDB {
     /**
      * Use new cache mechanism (an "invalidate" method of the old cache machanism will be invoked)
      * This method is useful if you want to call GC manually
-     * 
+     *
      * @param {Object} cacheObj
      * @return {Undefined}
      */
@@ -70,7 +70,7 @@ export default class NodeCouchDB {
      * Creates a database. Returns a promise which is
      * - resolved with no arguments
      * - rejected with `request` original error
-     * 
+     *
      * @param {String} dbName
      * @return {Promise}
      */
@@ -98,7 +98,7 @@ export default class NodeCouchDB {
      * Drops database by its name. Returns a promise which is
      * - resolved with no arguments
      * - rejected with `request` original error
-     * 
+     *
      * @param {String} dbName
      * @return {Promise}
      */
@@ -126,7 +126,7 @@ export default class NodeCouchDB {
      * Fetch data from CouchDB. Returns a promise which is
      * - resolved with {data, headers, status} object
      * - rejected with `request` original error
-     * 
+     *
      * @param {String} dbName database name
      * @param {String} uri document ID or design view
      * @param {Object} [query] query options as key: value
@@ -174,7 +174,7 @@ export default class NodeCouchDB {
      * Insert document into CouchDB. Returns a promise which is
      * - resolved with {data, headers, status} object
      * - rejected with `request` original error
-     * 
+     *
      * @param {String} dbName database name
      * @param {Object} data
      * @return {Promise}
@@ -185,8 +185,10 @@ export default class NodeCouchDB {
             url: `${this._baseUrl}/${dbName}`,
             body: data
         }).then(({res, body}) => {
-            if (res.statusCode === 409) {
-                throw new RequestError('EDOCCONFLICT', 'Document insert conflict', body);
+            this._checkDocumentManipulationStatus(res.statusCode, body)
+
+            if (res.statusCode !== 201 && res.statusCode !== 202) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while inserting document into the database: ${res.statusCode}`, body);
             }
 
             return {
@@ -201,7 +203,7 @@ export default class NodeCouchDB {
      * Update a document in CouchDB. Returns a promise which is
      * - resolved with {data, headers, status} object
      * - rejected with `request` original error
-     * 
+     *
      * @param {String} dbName database name
      * @param {Object} data should contain both "_id" and "_rev" fields
      * @return {Promise}
@@ -219,6 +221,13 @@ export default class NodeCouchDB {
             url: `${this._baseUrl}/${dbName}/${encodeURIComponent(data._id)}`,
             body: data
         }).then(({res, body}) => {
+            this._checkDocumentManipulationStatus(res.statusCode, body)
+
+
+            if (res.statusCode !== 201 && res.statusCode !== 202) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while inserting document into the database: ${res.statusCode}`, body);
+            }
+
             return {
                 data: body,
                 headers: res.headers,
@@ -231,7 +240,7 @@ export default class NodeCouchDB {
      * Delete a document in the database. Returns a promise which is
      * - resolved with {data, headers, status} object
      * - rejected with `request` original error
-     * 
+     *
      * @param {String} dbName database name
      * @param {String} docId document id
      * @param {String} docRevision document revision
@@ -245,9 +254,7 @@ export default class NodeCouchDB {
                 rev: docRevision
             }
         }).then(({res, body}) => {
-            if (res.statusCode === 404) {
-                throw new RequestError('EDOCMISSING', 'Document is not found', body);
-            }
+            this._checkDocumentManipulationStatus(res.statusCode, body)
 
             if (res.statusCode !== 200) {
                 throw new RequestError('EUNKNOWN', `Unexpected status code while deleting document: ${res.statusCode}`, body);
@@ -265,7 +272,7 @@ export default class NodeCouchDB {
      * Get UUIDs for new documents. Returns a promise which is
      * - resolved with array of new unique ids
      * - rejected with `request` original error
-     * 
+     *
      * @param {Number} [count = 1] number of IDs you want to get
      * @return {Promise}
      */
@@ -279,9 +286,34 @@ export default class NodeCouchDB {
     }
 
     /**
+     * Check the status code of a documentation manipulation like INSERT, UPDATE, DELETE
+     *
+     * @param {Number} statusCode
+     * @param {Object} body
+     * @throws {RequestError}
+     */
+    _checkDocumentManipulationStatus(statusCode, body) {
+      if (statusCode === 400) {
+          throw new RequestError('EBADREQUEST', 'Invalid request body or parameters', body);
+      }
+
+      if (statusCode === 401) {
+          throw new RequestError('EUNAUTHORIZED', 'Write privileges required', body);
+      }
+
+      if (statusCode === 404) {
+          throw new RequestError('EDOCMISSING', 'Document not found', body);
+      }
+
+      if (statusCode === 409) {
+          throw new RequestError('EDOCCONFLICT', 'Document insert conflict', body);
+      }
+    }
+
+    /**
      * Requests wrapper. Checks for cache first for GET requests.
      * Should be invoked with arguments suitable for `request`
-     * 
+     *
      * @return {Promise}
      */
     _requestWrapped(opts) {
@@ -321,9 +353,10 @@ export default class NodeCouchDB {
         });
     }
 
+
     /**
      * Gets cache key built from request options
-     * 
+     *
      * @param {Object} requestOpts
      * @return {String}
      */


### PR DESCRIPTION
In some cases the error handling was missing at the manipulating of the
document.
So if an error occurs the Promise fulfill successfully.
So added more checks for the status code which gets returned when a
document was manipulated.
