### PR TITLE
Upgrade request package in package.json from 2.79.0 to 2.85.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "nosql"
   ],
   "dependencies": {
-    "request": "^2.79.0"
+    "request": "^2.85.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",


### PR DESCRIPTION
Updating request package will solve error below.

hoek node module before 5.0.3 suffers from a Modification of Assumed-Immutable Data (MAID) vulnerability via 'merge' and 'applyToDefaults' functions, which allows a malicious user to modify the prototype of "Object" via __proto__, causing the addition or modification of an existing property that will exist on all objects.
reference: https://nvd.nist.gov/vuln/detail/CVE-2018-3728