### PR TITLE
Support 202 status code on database creation and drop

### DIFF
--- a/lib/node-couchdb.js
+++ b/lib/node-couchdb.js
@@ -92,7 +92,7 @@ export default class NodeCouchDB {
                 throw new RequestError('EBADREQUEST', res.body.reason, body);
             }
 
-            if (res.statusCode !== 201) {
+            if (res.statusCode !== 201 && res.statusCode !== 202) {
                 throw new RequestError('EUNKNOWN', `Unexpected status code while creating database ${dbName}: ${res.statusCode}`, body);
             }
         });

--- a/lib/node-couchdb.js
+++ b/lib/node-couchdb.js
@@ -120,7 +120,7 @@ export default class NodeCouchDB {
                 throw new RequestError('ENOTADMIN', `Should be authorized as admin to delete database: ${res.statusCode}`, body);
             }
 
-            if (res.statusCode !== 200) {
+            if (res.statusCode !== 200 && res.statusCode !== 202) {
                 throw new RequestError('EUNKNOWN', `Unexpected status code while deleting database ${dbName}: ${res.statusCode}`, body);
             }
         });


### PR DESCRIPTION
I noticed that after some time of using CouchDB it starts responding with status code 202 when creating or dropping a database. This seems to be completely okay behavior and the database works fine afterwards. The status could shouldn't lead to an error in node-couchdb.

```
couchdb_1  | [notice] 2020-10-15T14:59:01.006027Z nonode@nohost <0.6119.0> eaa36027fa localhost:5984 10.200.6.1 admin GET /_all_dbs?startkey=%22%22&endkey=%22%E9%A6%99%22&limit=30 200 ok 3
couchdb_1  | [notice] 2020-10-15T14:59:11.908620Z nonode@nohost <0.6119.0> 989f596a8e localhost:5984 10.200.6.1 admin PUT /hello 202 ok 32
couchdb_1  | [notice] 2020-10-15T14:59:11.997105Z nonode@nohost <0.6154.0> 7ce61a37d2 localhost:5984 10.200.6.1 admin GET /hello/_all_docs?startkey=%22_design%2F%22&endkey=%22_design0%22&include_docs=true&limit=501 200 ok 2
couchdb_1  | [notice] 2020-10-15T14:59:11.997293Z nonode@nohost <0.6156.0> 96196a5be9 localhost:5984 10.200.6.1 admin GET /hello 200 ok 2
couchdb_1  | [notice] 2020-10-15T14:59:12.007901Z nonode@nohost <0.6154.0> 007c1dcb8d localhost:5984 10.200.6.1 admin GET /hello 200 ok 2
couchdb_1  | [notice] 2020-10-15T14:59:12.033235Z nonode@nohost <0.6154.0> f0561cf546 localhost:5984 10.200.6.1 admin GET /hello/_all_docs?skip=0&limit=21 200 ok 2
couchdb_1  | [notice] 2020-10-15T14:59:12.442279Z nonode@nohost <0.6154.0> 8924fc7f90 localhost:5984 10.200.6.1 admin GET /hello/_all_docs?startkey=%22%22&endkey=%22%E9%A6%99%22&limit=30 200 ok 5
```