### PR TITLE
Fix issue where orphan DB was created by a test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -95,6 +95,7 @@ describe('node-couchdb tests', () => {
         const promise = couch.createDatabase(dbName)
             .catch(function(){ /* no error handling */ });
         assert.instanceOf(promise, Promise, 'createDatabase() result is not a promise');
+        return promise;
     });
 
     it('should create new database', () => {


### PR DESCRIPTION
To reproduce this issue, run the tests with npm test. The test "should return promise for createDatabase operation" does not properly return the promise after the assert test, so the afterEach hook that cleans up the created database does not run. You will see a sample DB created from this test in your CouchDB instance. With this PR, we return the promise, which tells the afterEach hook to run. No more orphan sample DB.