### PR TITLE
(v2) Use CouchDB v3 security defaults for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 .DS_Store?
 
+.env
+
 lib-cov
 *.seed
 *.log
@@ -17,3 +19,5 @@ results
 npm-debug.log
 node_modules
 dist/
+
+cleanup.js

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,3 @@ results
 npm-debug.log
 node_modules
 dist/
-
-cleanup.js

--- a/README.md
+++ b/README.md
@@ -19,28 +19,34 @@ npm install node-couchdb --save
 const NodeCouchDb = require('node-couchdb');
 
 // node-couchdb instance with default options
-const couch = new NodeCouchDb();
+const couch = new NodeCouchDb({
+    auth: {
+        user: AUTH_USER,
+        pass: AUTH_PASS
+    }
+});
 
 // node-couchdb instance with Memcached
 const MemcacheNode = require('node-couchdb-plugin-memcached');
 const couchWithMemcache = new NodeCouchDb({
-    cache: new MemcacheNode
+    cache: new MemcacheNode,
+    auth: {
+        user: AUTH_USER,
+        pass: AUTH_PASS
+    }
 });
 
 // node-couchdb instance talking to external service
 const couchExternal = new NodeCouchDb({
     host: 'couchdb.external.service',
     protocol: 'https',
-    port: 6984
-});
-
-// not admin party
-const couchAuth = new NodeCouchDb({
+    port: 6984,
     auth: {
-        user: 'login',
-        pass: 'secret'
+        user: AUTH_USER,
+        pass: AUTH_PASS
     }
 });
+
 ```
 
 All node-couchdb methods return Promise instances which resolve if everything works as expected and reject with Error instance which usually has `code` and `body` fields. See package source and tests for more info.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=14"
+    "node": ">=6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,10 +44,11 @@
     "babel-register": "^6.7.2",
     "chai": "^4.1.1",
     "mocha": "^6.0.0",
+    "dotenv": "^16.0.1",
     "node-couchdb-plugin-memory": "^0.0.2"
   },
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=14"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -4,12 +4,13 @@ import {assert} from 'chai';
 import request from 'request';
 import memoryCache from 'node-couchdb-plugin-memory';
 import nodeCouchDb from '../lib/node-couchdb';
+import 'dotenv/config';
 
-const noop = function () {}
+const noop = function () {};
 const cache = new memoryCache;
 
-const AUTH_USER = 'some_login';
-const AUTH_PASS = 'secret_pass';
+const AUTH_USER = process.env.COUCHDB_USER;
+const AUTH_PASS = process.env.COUCHDB_PASS;
 
 describe('node-couchdb tests', () => {
     let dbName;
@@ -17,7 +18,12 @@ describe('node-couchdb tests', () => {
 
     beforeEach(() => {
         dbName = `sample${Date.now()}`;
-        couch = new nodeCouchDb;
+        couch = new nodeCouchDb({
+            auth: {
+                user: AUTH_USER,
+                pass: AUTH_PASS
+            }
+        });
     });
 
     afterEach(done => {
@@ -531,67 +537,25 @@ describe('node-couchdb tests', () => {
             });
     });
 
-    function createAdmin() {
-        return new Promise((resolve, reject) => {
-            request.put({
-                url: `http://127.0.0.1:5984/_config/admins/${AUTH_USER}`,
-                body: JSON.stringify(AUTH_PASS)
-            }, (err, res, body) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            });
-        });
-    }
-
-    function addDbSecurity(dbName) {
-        return new Promise(function(resolve, reject) {
-            const opts = {
-                method: 'PUT',
-                url: `http://127.0.0.1:5984/${dbName}/_security`,
-                body: {"admins": { "names": ['somename'],"roles": []}, "members": {"names": ['somename'],"roles": []}},
-                json: true
-            };
-
-            request(opts, function(err, response, body) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve();
-            })
-        })
-    }
-
-    // auth
-    // @see http://guide.couchdb.org/draft/security.html#authentication
-    // @see https://github.com/1999/node-couchdb/issues/4
     it('should use basic auth for admin features', () => {        
-        return createAdmin()
-            .then(() => couch.createDatabase(dbName))
+        const couchNonAuth = new nodeCouchDb;
+
+        return couchNonAuth.createDatabase(dbName)
             .then(() => {
                 throw new Error('admin party is off but createDatabase() op promise has been resolved');
             }, err => {
                 assert.instanceOf(err, Error, 'err is not an instance of Error');
                 assert.strictEqual(err.code, 'ENOTADMIN', 'err code is not ENOTADMIN');
 
-                const couchAuth = new nodeCouchDb({
-                    auth: {
-                        user: AUTH_USER,
-                        pass: AUTH_PASS
-                    }
-                });
-
-                return couchAuth.createDatabase(dbName);
+                return couch.createDatabase(dbName);
             });
     });
 
     it('should reject insert promise with EUNAUTHORIZED if user is not logged in', () => {
+        const couchNonAuth = new nodeCouchDb;
+
         return couch.createDatabase(dbName)
-            .then(() => addDbSecurity(dbName))
-            .then(() => createAdmin())
-            .then(() => couch.insert(dbName, {}))
+            .then(() => couchNonAuth.insert(dbName, {}))
             .then(() => {
                 throw new Error(`Inserting into the database ${dbName} without auth didn't fail`);
             }, err => {
@@ -602,10 +566,10 @@ describe('node-couchdb tests', () => {
 
 
     it('should reject update promise with EUNAUTHORIZED if user is not logged in', () => {
+        const couchNonAuth = new nodeCouchDb;
+
         return couch.createDatabase(dbName)
-            .then(() => addDbSecurity(dbName))
-            .then(() => createAdmin())
-            .then(() => couch.update(dbName, {_id: 123, _rev: 1}))
+            .then(() => couchNonAuth.update(dbName, {_id: 123, _rev: 1}))
             .then(() => {
                 throw new Error(`Updating into the database ${dbName} without auth didn't fail`);
             }, err => {
@@ -615,10 +579,10 @@ describe('node-couchdb tests', () => {
     });
 
     it('should reject delete promise with EUNAUTHORIZED if user is not logged in', () => {
+        const couchNonAuth = new nodeCouchDb;
+
         return couch.createDatabase(dbName)
-            .then(() => addDbSecurity(dbName))
-            .then(() => createAdmin())
-            .then(() => couch.del(dbName, 123, 1))
+            .then(() => couchNonAuth.del(dbName, 123, 1))
             .then(() => {
                 throw new Error(`Deleting into the database ${dbName} without auth didn't fail`);
             }, err => {


### PR DESCRIPTION
CouchDB v3 (the currently supported version) has the admin party disabled by default. If someone were to use this package with a new install of CouchDB and run these tests, they would fail, because the tests assume that admin party is the default. So this PR does the following:
* Changes tests to use authenticated user by default
* Adds dotenv to the dev dependencies
* Updates examples in the README