### PR TITLE
Fix mango example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ couch.get(dbName, viewUrl, queryOptions).then(({data, headers, status}) => {
 const dbName = "database";
 const mangoQuery = {
     selector: {
-        $gte: {firstname: 'Ann'},
-        $lt: {firstname: 'George'}
+        firstname: {
+            $gte: 'Ann',
+            $lt: 'George'
+        }
     }
 };
 const parameters = {};


### PR DESCRIPTION
Fixes the README to have the correct order of properties for a mango query. Follows CouchDB v3 documentation rules for forming the query.