### PR TITLE
(v2) Migrate from Request to Node-Fetch

### DIFF
--- a/lib/node-couchdb.js
+++ b/lib/node-couchdb.js
@@ -1,7 +1,7 @@
 'use strict';
-
 import crypto from 'crypto';
-import request from 'request';
+import fetch from 'node-fetch';
+import AbortController from 'abort-controller';
 
 // @see https://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options
 // @see https://github.com/1999/node-couchdb/issues/9
@@ -27,17 +27,27 @@ export default class NodeCouchDB {
             auth: null
         }, opts);
 
-        this._baseUrl = `${instanceOpts.protocol}://${instanceOpts.host}:${instanceOpts.port}`;
-        this._cache = instanceOpts.cache;
+        this._baseUrl = `${instanceOpts.protocol}://`;
+        this._baseUrl += `${instanceOpts.host}:${instanceOpts.port}`;
 
-        this._requestWrappedDefaults = request.defaults({
-            auth: instanceOpts.auth,
-            headers: {
-                'user-agent': 'node-couchdb/1'
-            },
-            json: true,
-            timeout: instanceOpts.timeout
-        });
+        this._cache = instanceOpts.cache;
+        this._timeoutMs = instanceOpts.timeout;
+
+        const defaultHeaders = {
+            'user-agent': 'node-couchdb/1',
+            'content-type': 'application/json'
+        };
+
+        if (instanceOpts.auth) {
+            const str = `${instanceOpts.auth.user}:${instanceOpts.auth.pass}`;
+            const b64 = Buffer.from(str, 'utf8').toString('base64');
+            defaultHeaders['authorization'] = 'Basic ' + b64;
+        }
+
+
+        this._fetchDefaultOpts = {
+            headers: defaultHeaders,
+        };
     }
 
     /**
@@ -63,7 +73,7 @@ export default class NodeCouchDB {
      * @return {Promise}
      */
     listDatabases() {
-        return this._requestWrapped(`${this._baseUrl}/_all_dbs`).then(({body}) => body);
+        return this._fetchWrapped(`${this._baseUrl}/_all_dbs`).then(({body}) => body);
     }
 
     /**
@@ -75,25 +85,24 @@ export default class NodeCouchDB {
      * @return {Promise}
      */
     createDatabase(dbName) {
-        return this._requestWrapped({
+        return this._fetchWrapped(`${this._baseUrl}/${dbName}`, {
             method: 'PUT',
-            url: `${this._baseUrl}/${dbName}`
         }).then(({res, body}) => {
             // database already exists
-            if (res.statusCode === 412) {
+            if (res.status === 412) {
                 throw new RequestError('EDBEXISTS', `Database already exists: ${dbName}`, body);
             }
 
-            if (res.statusCode === 401) {
-                throw new RequestError('ENOTADMIN', `Should be authorized as admin to create database: ${res.statusCode}`, body);
+            if (res.status === 401) {
+                throw new RequestError('ENOTADMIN', `Should be authorized as admin to create database: ${res.status}`, body);
             }
 
-            if (res.statusCode === 400) {
+            if (res.status === 400) {
                 throw new RequestError('EBADREQUEST', res.body.reason, body);
             }
 
-            if (res.statusCode !== 201 && res.statusCode !== 202) {
-                throw new RequestError('EUNKNOWN', `Unexpected status code while creating database ${dbName}: ${res.statusCode}`, body);
+            if (res.status !== 201 && res.status !== 202) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while creating database ${dbName}: ${res.status}`, body);
             }
         });
     }
@@ -107,21 +116,21 @@ export default class NodeCouchDB {
      * @return {Promise}
      */
     dropDatabase(dbName) {
-        return this._requestWrapped({
+        const url = `${this._baseUrl}/${dbName}/`;
+        return this._fetchWrapped(url, {
             method: 'DELETE',
-            url: `${this._baseUrl}/${dbName}/`
         }).then(({res, body}) => {
             // database not found
-            if (res.statusCode === 404) {
+            if (res.status === 404) {
                 throw new RequestError('EDBMISSING', `Database not found: ${dbName}`, body);
             }
 
-            if (res.statusCode === 401) {
-                throw new RequestError('ENOTADMIN', `Should be authorized as admin to delete database: ${res.statusCode}`, body);
+            if (res.status === 401) {
+                throw new RequestError('ENOTADMIN', `Should be authorized as admin to delete database: ${res.status}`, body);
             }
 
-            if (res.statusCode !== 200 && res.statusCode !== 202) {
-                throw new RequestError('EUNKNOWN', `Unexpected status code while deleting database ${dbName}: ${res.statusCode}`, body);
+            if (res.status !== 200 && res.status !== 202) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while deleting database ${dbName}: ${res.status}`, body);
             }
         });
     }
@@ -137,39 +146,38 @@ export default class NodeCouchDB {
      * @return {Promise}
      */
     get(dbName, uri, query = {}) {
+        const url = new URL(`${this._baseUrl}/${dbName}/${uri}`); 
+
         for (let prop in query) {
             if (KEYS_TO_ENCODE.includes(prop)) {
-                query[prop] = JSON.stringify(query[prop]);
+                url.searchParams.set(prop, JSON.stringify(query[prop]));
+            } else {
+                url.searchParams.set(prop, query[prop]);
             }
         }
 
-        const requestOpts = {
-            url: `${this._baseUrl}/${dbName}/${encodeURIComponent(uri)}`,
-            qs: query
-        };
-
-        return this._requestWrapped(requestOpts).then(({res, body}) => {
-            if (res.statusCode === 404) {
+        return this._fetchWrapped(url).then(({res, body}) => {
+            if (res.status === 404) {
                 throw new RequestError('EDOCMISSING', 'Document is not found', body);
             }
 
-            if (res.statusCode !== 200 && res.statusCode !== 304) {
-                throw new RequestError('EUNKNOWN', `Unexpected status code while fetching documents from the database: ${res.statusCode}`, body);
+            if (res.status !== 200 && res.status !== 304) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while fetching documents from the database: ${res.status}`, body);
             }
 
-            if (res.statusCode === 200 && this._cache) {
-                const cacheKey = this._getCacheKey(requestOpts);
+            if (res.status === 200 && this._cache) {
+                const cacheKey = this._getCacheKey(url);
 
                 this._cache.set(cacheKey, {
                     body,
-                    etag: res.headers.etag
+                    etag: res.headers.get('ETag')
                 });
             }
 
             return {
                 data: body,
                 headers: res.headers,
-                status: res.statusCode
+                status: res.status
             };
         });
     }
@@ -186,36 +194,32 @@ export default class NodeCouchDB {
      * @return {Promise}
      */
     getAttachment(dbName, docId, attachmentName, docRevision) {
-        var requestOpts = {
-            method: 'GET',
-            url: `${this._baseUrl}/${dbName}/${docId}/${attachmentName}`,
-            qs: {
-                rev: docRevision
-            }
-        };
 
-        return this._requestWrapped(requestOpts).then(({res, body}) => {
-            if (res.statusCode === 404) {
+        const url = new URL(`${this._baseUrl}/${dbName}/${docId}/${attachmentName}`);
+        url.searchParams.set('rev', docRevision);
+
+        return this._fetchWrapped(url).then(({res, body}) => {
+            if (res.status === 404) {
                 throw new RequestError('EDOCMISSING', 'Attachment is not found', body);
             }
 
-            if (res.statusCode !== 200 && res.statusCode !== 304) {
-                throw new RequestError('EUNKNOWN', `Unexpected status code while fetching attachment from the database: ${res.statusCode}`, body);
+            if (res.status !== 200 && res.status !== 304) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while fetching attachment from the database: ${res.status}`, body);
             }
 
-            if (res.statusCode === 200 && this._cache) {
-                const cacheKey = this._getCacheKey(requestOpts);
+            if (res.status === 200 && this._cache) {
+                const cacheKey = this._getCacheKey(url);
 
                 this._cache.set(cacheKey, {
                     body,
-                    etag: res.headers.etag
+                    etag: res.headers.get('ETag')
                 });
             }
 
             return {
                 data: body,
                 headers: res.headers,
-                status: res.statusCode
+                status: res.status
             };
         });
     }
@@ -230,21 +234,21 @@ export default class NodeCouchDB {
      * @return {Promise}
      */
     insert(dbName, data) {
-        return this._requestWrapped({
+        const url = `${this._baseUrl}/${dbName}`;
+        return this._fetchWrapped(url, {
             method: 'POST',
-            url: `${this._baseUrl}/${dbName}`,
-            body: data
+            body: JSON.stringify(data)
         }).then(({res, body}) => {
-            this._checkDocumentManipulationStatus(res.statusCode, body)
+            this._checkDocumentManipulationStatus(res.status, body)
 
-            if (res.statusCode !== 201 && res.statusCode !== 202) {
-                throw new RequestError('EUNKNOWN', `Unexpected status code while inserting document into the database: ${res.statusCode}`, body);
+            if (res.status !== 201 && res.status !== 202) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while inserting document into the database: ${res.status}`, body);
             }
 
             return {
                 data: body,
                 headers: res.headers,
-                status: res.statusCode
+                status: res.status
             };
         });
     }
@@ -262,22 +266,20 @@ export default class NodeCouchDB {
      * @return {Promise}
      */
     insertAttachment(dbName, docId, attachmentName, body, docRevision) {
-        return this._requestWrapped({
+        const url = new URL(`${this._baseUrl}/${dbName}/${encodeURIComponent(docId)}/attachment`);
+        url.searchParams.set('rev', docRevision);
+        return this._fetchWrapped(url, {
             method: 'PUT',
-            url: `${this._baseUrl}/${dbName}/${encodeURIComponent(docId)}/attachment`,
-            qs: {
-                rev: docRevision
-            },
-            body: body
+            body: JSON.stringify(body)
         }).then(({res, body}) => {
-            if (res.statusCode === 409) {
+            if (res.status === 409) {
                 throw new RequestError('EDOCCONFLICT', 'Document insert conflict - Document’s revision wasn’t specified or it’s not the latest', body);
             }
 
             return {
                 data: body,
                 headers: res.headers,
-                status: res.statusCode
+                status: res.status
             };
         });
     }
@@ -299,22 +301,23 @@ export default class NodeCouchDB {
             return Promise.reject(err);
         }
 
-        return this._requestWrapped({
+        const url = `${this._baseUrl}/${dbName}/${encodeURIComponent(data._id)}`;
+
+        return this._fetchWrapped(url, {
             method: 'PUT',
-            url: `${this._baseUrl}/${dbName}/${encodeURIComponent(data._id)}`,
-            body: data
+            body: JSON.stringify(data)
         }).then(({res, body}) => {
-            this._checkDocumentManipulationStatus(res.statusCode, body)
+            this._checkDocumentManipulationStatus(res.status, body)
 
 
-            if (!(res.statusCode >= 200 && res.statusCode <= 202)) {
-                throw new RequestError('EUNKNOWN', `Unexpected status code while inserting document into the database: ${res.statusCode}`, body);
+            if (!(res.status >= 200 && res.status <= 202)) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while inserting document into the database: ${res.status}`, body);
             }
 
             return {
                 data: body,
                 headers: res.headers,
-                status: res.statusCode
+                status: res.status
             };
         });
     }
@@ -330,23 +333,21 @@ export default class NodeCouchDB {
      * @return {Promise}
      */
     del(dbName, docId, docRevision) {
-        return this._requestWrapped({
+        const url = new URL(`${this._baseUrl}/${dbName}/${encodeURIComponent(docId)}`);
+        url.searchParams.set('rev', docRevision);
+        return this._fetchWrapped(url, {
             method: 'DELETE',
-            url: `${this._baseUrl}/${dbName}/${encodeURIComponent(docId)}`,
-            qs: {
-                rev: docRevision
-            }
         }).then(({res, body}) => {
-            this._checkDocumentManipulationStatus(res.statusCode, body)
+            this._checkDocumentManipulationStatus(res.status, body)
 
-            if (res.statusCode !== 200) {
-                throw new RequestError('EUNKNOWN', `Unexpected status code while deleting document: ${res.statusCode}`, body);
+            if (res.status !== 200) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while deleting document: ${res.status}`, body);
             }
 
             return {
                 data: body,
                 headers: res.headers,
-                status: res.statusCode
+                status: res.status
             };
         });
     }
@@ -361,12 +362,8 @@ export default class NodeCouchDB {
      * @param {Object} [query] query options as key: value
      * @return {Promise}
      */
-    mango(dbName, mangoQuery, query = {}) {
-        for (let prop in query) {
-            if (KEYS_TO_ENCODE.includes(prop)) {
-                query[prop] = JSON.stringify(query[prop]);
-            }
-        }
+    mango(dbName, mangoQuery) {
+        const url = new URL(`${this._baseUrl}/${dbName}/_find`);
 
         if (typeof mangoQuery === 'string') {
             try {
@@ -382,26 +379,24 @@ export default class NodeCouchDB {
 
         const requestOpts = {
             method: 'POST',
-            url: `${this._baseUrl}/${dbName}/_find`,
-            body: mangoQuery,
-            qs: query
+            body: JSON.stringify(mangoQuery),
         };
 
-        return this._requestWrapped(requestOpts).then(({res, body}) => {
-            this._checkServerVersion(res.headers.server, 2);
+        return this._fetchWrapped(url, requestOpts).then(({res, body}) => {
+            this._checkServerVersion(res.headers.get('Server'), 2);
 
-            if (res.statusCode === 404) {
+            if (res.status === 404) {
                 throw new RequestError('EDOCMISSING', 'Document is not found', body);
             }
 
-            if (res.statusCode !== 200 && res.statusCode !== 304) {
-                throw new RequestError('EUNKNOWN', `Unexpected status code while fetching documents from the database: ${res.statusCode}`, body);
+            if (res.status !== 200 && res.status !== 304) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while fetching documents from the database: ${res.status}`, body);
             }
 
             return {
                 data: body,
                 headers: res.headers,
-                status: res.statusCode
+                status: res.status
             };
         });
     }
@@ -418,25 +413,24 @@ export default class NodeCouchDB {
      * @return {Promise}
      */
     delAttachment(dbName, docId, attachmentName, docRevision) {
-        return this._requestWrapped({
+        const url = new URL(`${this._baseUrl}/${dbName}/${encodeURIComponent(docId)}/${encodeURIComponent(attachmentName)}`);
+        url.searchParams.set('rev', docRevision);
+
+        return this._fetchWrapped(url, {
             method: 'DELETE',
-            url: `${this._baseUrl}/${dbName}/${encodeURIComponent(docId)}/${encodeURIComponent(attachmentName)}`,
-            qs: {
-                rev: docRevision
-            }
         }).then(({res, body}) => {
-            if (res.statusCode === 404) {
+            if (res.status === 404) {
                 throw new RequestError('EDOCMISSING', 'Attachment is not found', body);
             }
 
-            if (res.statusCode !== 200) {
-                throw new RequestError('EUNKNOWN', `Unexpected status code while deleting attachment: ${res.statusCode}`, body);
+            if (res.status !== 200) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while deleting attachment: ${res.status}`, body);
             }
 
             return {
                 data: body,
                 headers: res.headers,
-                status: res.statusCode
+                status: res.status
             };
         });
     }
@@ -461,28 +455,30 @@ export default class NodeCouchDB {
         let url;
 
         if (method === 'PUT') {
-            url = `${this._baseUrl}/${dbName}/_design/${designDocument}/_update/${updateFunctionName}/${encodeURIComponent(docId)}`;
+            url = new URL(`${this._baseUrl}/${dbName}/_design/${designDocument}/_update/${updateFunctionName}/${docId}`);
         } else {
-            url = `${this._baseUrl}/${dbName}/_design/${designDocument}/_update/${updateFunctionName}`;
+            url = new URL(`${this._baseUrl}/${dbName}/_design/${designDocument}/_update/${updateFunctionName}`);
+        }
+        
+        for (let prop in queryString) {
+            url.searchParams.set(prop, queryString[prop]);
         }
 
-        return this._requestWrapped({
+        return this._fetchWrapped(url, {
             method: method,
-            url: url,
-            qs: queryString
         }).then(({res, body}) => {
-            if (res.statusCode === 404) {
+            if (res.status === 404) {
                 throw new RequestError('EDOCMISSING', 'Design document is not found', body);
             }
 
-            if (res.statusCode !== 200 && res.statusCode !== 201 && res.statusCode !== 202) {
-                throw new RequestError('EUNKNOWN', `Unexpected status code while calling update function: ${res.statusCode}`, body);
+            if (res.status !== 200 && res.status !== 201 && res.status !== 202) {
+                throw new RequestError('EUNKNOWN', `Unexpected status code while calling update function: ${res.status}`, body);
             }
 
             return {
                 data: body,
                 headers: res.headers,
-                status: res.statusCode
+                status: res.status
             };
         });
     }
@@ -496,10 +492,10 @@ export default class NodeCouchDB {
      * @return {Promise}
      */
     uniqid(count = 1) {
-        return this._requestWrapped({
-            url: `${this._baseUrl}/_uuids`,
-            qs: {count}
-        }).then(({body}) => {
+        const url = new URL(`${this._baseUrl}/_uuids`); 
+        url.searchParams.set('count', count);
+
+        return this._fetchWrapped(url).then(({body}) => {
             return body.uuids;
         });
     }
@@ -535,39 +531,58 @@ export default class NodeCouchDB {
      *
      * @return {Promise}
      */
-    _requestWrapped(opts) {
-        if (typeof opts === 'string') {
-            opts = {url: opts};
-        }
+    async _fetchWrapped(url, opts) {
 
-        const cacheKey = this._getCacheKey(opts);
+        opts = opts || {};
+
+        const cacheKey = this._getCacheKey(url);
         const whenCacheChecked = (!this._cache || (opts.method && opts.method !== 'GET'))
             ? Promise.resolve({})
             : this._cache.get(cacheKey);
 
         return whenCacheChecked.then(cache => {
+
             // cache plugin returns null if record doesn't exist
             const {
                 etag,
                 body: cacheBody
             } = cache || {};
 
-            return new Promise((resolve, reject) => {
+            return new Promise(async (resolve, reject) => {
+                opts = Object.assign({ ... this._fetchDefaultOpts }, opts);
+
                 if (etag) {
                     opts.headers = opts.headers || {};
                     opts.headers['if-none-match'] = etag;
                 }
 
-                this._requestWrappedDefaults(opts, (err, res, body) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve({
-                            res,
-                            body: body || cacheBody
-                        });
+                const controller = new AbortController();
+                const timeout = setTimeout(() => controller.abort(), this._timeoutMs);
+                opts.signal = controller.signal;
+
+                try {
+                    const res = await fetch(url, opts);
+
+                    let data = null;
+                    if (res.ok) {
+                        const contentType = res.headers.get('content-type');
+
+                        if (contentType.includes('application/json')) {
+                            data = await res.json();
+                        } else if (contentType.includes('text/html')){
+                            data = await res.text();
+                        }
                     }
-                });
+
+                    resolve({
+                        res,
+                        body: data || cacheBody
+                    });
+                } catch (err) {
+                    reject(err);
+                } finally {
+                    clearTimeout(timeout);
+                }
             });
         });
     }
@@ -579,10 +594,8 @@ export default class NodeCouchDB {
      * @param {Object} requestOpts
      * @return {String}
      */
-    _getCacheKey(requestOpts) {
-        const stringifiedQuery = JSON.stringify(requestOpts.query || {});
-        const cacheKeyFull = `${requestOpts.url}?${stringifiedQuery}`;
-
+    _getCacheKey(url) {
+        const cacheKeyFull = url.toString();
         return crypto.createHash('md5').update(cacheKeyFull).digest('hex');
     }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "nosql"
   ],
   "dependencies": {
-    "request": "^2.85.0"
+    "abort-controller": "^3.0.0",
+    "node-fetch": "^2"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",


### PR DESCRIPTION
Migrates source code and tests away from the deprecated Request package to Node-Fetch, which should make the transition to Node's global Fetch easier, whenever that feature is no longer experimental.